### PR TITLE
BUG: pyqt is actually required to run the app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ install_requires =
     h5py ==3.*
     matplotlib ==3.*
     numpy ==1.*
+    pyqt5 ==5.*
     scipy ==1.*
     watchdog ==2.*
 


### PR DESCRIPTION
Although opening a GUI is not required to run the app (supposedly). There are many objects from pyqt which are imported across many modules, so pyqt is required to be installed.