### PR TITLE
REL: Do not include test files in git release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .git_archival.txt  export-subst
 test/fly085/positions/fly085_0.txt filter=lfs diff=lfs merge=lfs -text
 test/fly085/* filter=lfs diff=lfs merge=lfs -text
+test/fly085/* export-ignore


### PR DESCRIPTION
Add a note to the .gitattributes to not include the test data in the git archives