### PR TITLE
NEW: Display the mouse coordinates on the image

### DIFF
--- a/ptychodus/view/core.py
+++ b/ptychodus/view/core.py
@@ -47,7 +47,7 @@ class ViewCore(QMainWindow):
         self.detectorAction = self.navigationToolBar.addAction(QIcon(':/icons/detector'),
                                                                'Detector')
         self.detectorView = DetectorView.createInstance()
-        self.detectorImageView = ImageView.createInstance()
+        self.detectorImageView = ImageView.createInstance(self.statusBar())
 
         self.scanAction = self.navigationToolBar.addAction(QIcon(':/icons/scan'), 'Scan')
         self.scanView = ScanView.createInstance()
@@ -55,11 +55,11 @@ class ViewCore(QMainWindow):
 
         self.probeAction = self.navigationToolBar.addAction(QIcon(':/icons/probe'), 'Probe')
         self.probeView = ProbeView.createInstance()
-        self.probeImageView = ImageView.createInstance()
+        self.probeImageView = ImageView.createInstance(self.statusBar())
 
         self.objectAction = self.navigationToolBar.addAction(QIcon(':/icons/object'), 'Object')
         self.objectView = ObjectView.createInstance()
-        self.objectImageView = ImageView.createInstance()
+        self.objectImageView = ImageView.createInstance(self.statusBar())
 
         self.reconstructorAction = self.navigationToolBar.addAction(QIcon(':/icons/reconstructor'),
                                                                     'Reconstructor')
@@ -77,8 +77,8 @@ class ViewCore(QMainWindow):
         self.automationWidget = QWidget()
 
         self.monitorAction = self.navigationToolBar.addAction(QIcon(':/icons/monitor'), 'Monitor')
-        self.monitorProbeView = MonitorProbeView.createInstance()
-        self.monitorObjectView = MonitorObjectView.createInstance()
+        self.monitorProbeView = MonitorProbeView.createInstance(self.statusBar())
+        self.monitorObjectView = MonitorObjectView.createInstance(self.statusBar())
 
     @classmethod
     def createInstance(cls,

--- a/ptychodus/view/monitor.py
+++ b/ptychodus/view/monitor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Optional
 
-from PyQt5.QtWidgets import QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QVBoxLayout, QWidget, QStatusBar
 
 from .image import ImageView
 from .widgets import BottomTitledGroupBox
@@ -9,13 +9,13 @@ from .widgets import BottomTitledGroupBox
 
 class MonitorProbeView(BottomTitledGroupBox):
 
-    def __init__(self, parent: Optional[QWidget]) -> None:
+    def __init__(self, statusbar: QStatusBar, parent: Optional[QWidget]) -> None:
         super().__init__('Probe', parent)
-        self.imageView = ImageView.createInstance()
+        self.imageView = ImageView.createInstance(statusbar)
 
     @classmethod
-    def createInstance(cls, parent: Optional[QWidget] = None) -> MonitorProbeView:
-        view = cls(parent)
+    def createInstance(cls, statusbar: QStatusBar, parent: Optional[QWidget] = None) -> MonitorProbeView:
+        view = cls(statusbar, parent)
 
         layout = QVBoxLayout()
         layout.setContentsMargins(10, 10, 10, 30)
@@ -27,13 +27,13 @@ class MonitorProbeView(BottomTitledGroupBox):
 
 class MonitorObjectView(BottomTitledGroupBox):
 
-    def __init__(self, parent: Optional[QWidget]) -> None:
+    def __init__(self, statusbar: QStatusBar, parent: Optional[QWidget]) -> None:
         super().__init__('Object', parent)
-        self.imageView = ImageView.createInstance()
+        self.imageView = ImageView.createInstance(statusbar)
 
     @classmethod
-    def createInstance(cls, parent: Optional[QWidget] = None) -> MonitorObjectView:
-        view = cls(parent)
+    def createInstance(cls, statusbar: QStatusBar, parent: Optional[QWidget] = None) -> MonitorObjectView:
+        view = cls(statusbar, parent)
 
         layout = QVBoxLayout()
         layout.setContentsMargins(10, 10, 10, 30)


### PR DESCRIPTION
The purpose of this PR is to help with locating the center of a diffraction pattern in the viewer. Now when you click on a pixel in the viewer, the coordinates of that pixel appear in the status bar at the bottom of the main window.