### PR TITLE
GUI: Remove deleted reconstruction algorithms from GUI

### DIFF
--- a/ptychodus/controller/tike/factory.py
+++ b/ptychodus/controller/tike/factory.py
@@ -24,14 +24,6 @@ class TikeViewControllerFactory(ReconstructorViewControllerFactory):
             view = TikeParametersView.createInstance(showCgIter=False,
                                                      showAlpha=True,
                                                      showStepLength=False)
-        elif reconstructorName == 'adam_grad':
-            view = TikeParametersView.createInstance(showCgIter=False,
-                                                     showAlpha=True,
-                                                     showStepLength=True)
-        elif reconstructorName == 'cgrad':
-            view = TikeParametersView.createInstance(showCgIter=True,
-                                                     showAlpha=False,
-                                                     showStepLength=True)
         elif reconstructorName == 'lstsq_grad':
             view = TikeParametersView.createInstance(showCgIter=False,
                                                      showAlpha=False,

--- a/ptychodus/model/tike/core.py
+++ b/ptychodus/model/tike/core.py
@@ -172,8 +172,6 @@ class TikeReconstructorLibrary(ReconstructorLibrary):
         core = cls(settingsRegistry)
 
         try:
-            from .reconstructor import AdaptiveMomentGradientDescentReconstructor
-            from .reconstructor import ConjugateGradientReconstructor
             from .reconstructor import DifferenceMapReconstructor
             from .reconstructor import IterativeLeastSquaresReconstructor
             from .reconstructor import RegularizedPIEReconstructor
@@ -183,8 +181,6 @@ class TikeReconstructorLibrary(ReconstructorLibrary):
 
             if isDeveloperModeEnabled:
                 core.reconstructorList.append(NullReconstructor('rpie'))
-                core.reconstructorList.append(NullReconstructor('adam_grad'))
-                core.reconstructorList.append(NullReconstructor('cgrad'))
                 core.reconstructorList.append(NullReconstructor('lstsq_grad'))
                 core.reconstructorList.append(NullReconstructor('dm'))
         else:
@@ -193,9 +189,6 @@ class TikeReconstructorLibrary(ReconstructorLibrary):
                                                   core._probeCorrectionSettings,
                                                   core._objectCorrectionSettings)
             core.reconstructorList.append(RegularizedPIEReconstructor(tikeReconstructor))
-            core.reconstructorList.append(
-                AdaptiveMomentGradientDescentReconstructor(tikeReconstructor))
-            core.reconstructorList.append(ConjugateGradientReconstructor(tikeReconstructor))
             core.reconstructorList.append(IterativeLeastSquaresReconstructor(tikeReconstructor))
             core.reconstructorList.append(DifferenceMapReconstructor(tikeReconstructor))
 

--- a/ptychodus/model/tike/reconstructor.py
+++ b/ptychodus/model/tike/reconstructor.py
@@ -252,56 +252,6 @@ class RegularizedPIEReconstructor(Reconstructor):
         return self._tikeReconstructor(parameters, self._algorithmOptions)
 
 
-class AdaptiveMomentGradientDescentReconstructor(Reconstructor):
-
-    def __init__(self, tikeReconstructor: TikeReconstructor) -> None:
-        super().__init__()
-        self._algorithmOptions = tike.ptycho.solvers.AdamOptions()
-        self._tikeReconstructor = tikeReconstructor
-
-    @property
-    def name(self) -> str:
-        return self._algorithmOptions.name
-
-    @property
-    def _settings(self) -> TikeSettings:
-        return self._tikeReconstructor._settings
-
-    def reconstruct(self, parameters: ReconstructInput) -> ReconstructOutput:
-        self._algorithmOptions.num_batch = self._settings.numBatch.value
-        self._algorithmOptions.batch_method = self._settings.batchMethod.value
-        self._algorithmOptions.num_iter = self._settings.numIter.value
-        self._algorithmOptions.convergence_window = self._settings.convergenceWindow.value
-        self._algorithmOptions.alpha = float(self._settings.alpha.value)
-        self._algorithmOptions.step_length = float(self._settings.stepLength.value)
-        return self._tikeReconstructor(parameters, self._algorithmOptions)
-
-
-class ConjugateGradientReconstructor(Reconstructor):
-
-    def __init__(self, tikeReconstructor: TikeReconstructor) -> None:
-        super().__init__()
-        self._algorithmOptions = tike.ptycho.solvers.CgradOptions()
-        self._tikeReconstructor = tikeReconstructor
-
-    @property
-    def name(self) -> str:
-        return self._algorithmOptions.name
-
-    @property
-    def _settings(self) -> TikeSettings:
-        return self._tikeReconstructor._settings
-
-    def reconstruct(self, parameters: ReconstructInput) -> ReconstructOutput:
-        self._algorithmOptions.num_batch = self._settings.numBatch.value
-        self._algorithmOptions.batch_method = self._settings.batchMethod.value
-        self._algorithmOptions.num_iter = self._settings.numIter.value
-        self._algorithmOptions.convergence_window = self._settings.convergenceWindow.value
-        self._algorithmOptions.cg_iter = self._settings.cgIter.value
-        self._algorithmOptions.step_length = float(self._settings.stepLength.value)
-        return self._tikeReconstructor(parameters, self._algorithmOptions)
-
-
 class IterativeLeastSquaresReconstructor(Reconstructor):
 
     def __init__(self, tikeReconstructor: TikeReconstructor) -> None:


### PR DESCRIPTION
Tike has removed conjugate gradient and adam from its reconstruction options in v0.25. This PR removes these algorithms from the GUI. I believe that this change is backwards compatible with tike v0.24 because it just removes calls to the API.