### PR TITLE
NEW: Use matplotlib fill_between to show object function uncertainty for multi-batch reconstructions

### DIFF
--- a/ptychodus/api/plot.py
+++ b/ptychodus/api/plot.py
@@ -18,6 +18,12 @@ class PlotSeries:
     label: str
     values: Sequence[float]
 
+@dataclass(frozen=True)
+class PlotUncertainSeries:
+    label: str
+    lo:  Sequence[float]
+    values: Sequence[float]
+    hi: Sequence[float]
 
 @dataclass(frozen=True)
 class PlotAxis:
@@ -30,6 +36,16 @@ class PlotAxis:
 
 
 @dataclass(frozen=True)
+class PlotUncertainAxis:
+    label: str
+    series: Sequence[PlotUncertainSeries]
+
+    @classmethod
+    def createNull(cls) -> PlotUncertainAxis:
+        return cls('', [])
+
+
+@dataclass(frozen=True)
 class Plot2D:
     axisX: PlotAxis
     axisY: PlotAxis
@@ -37,6 +53,16 @@ class Plot2D:
     @classmethod
     def createNull(cls) -> Plot2D:
         return cls(PlotAxis.createNull(), PlotAxis.createNull())
+
+
+@dataclass(frozen=True)
+class PlotUncertain2D:
+    axisX: PlotAxis
+    axisY: PlotUncertainAxis
+
+    @classmethod
+    def createNull(cls) -> PlotUncertain2D:
+        return cls(PlotAxis.createNull(), PlotUncertainAxis.createNull())
 
 
 @dataclass(frozen=True)

--- a/ptychodus/api/reconstructor.py
+++ b/ptychodus/api/reconstructor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from .data import DiffractionPatternArrayType
 from .image import ImageExtent
 from .object import ObjectArrayType, ObjectInterpolator
-from .plot import Plot2D
+from .plot import Plot2D, PlotUncertain2D
 from .probe import ProbeArrayType
 from .scan import Scan
 
@@ -51,7 +51,7 @@ class ReconstructOutput:
     probeArray: ProbeArrayType | None
     objectArray: ObjectArrayType | None
     objective: Sequence[Sequence[float]]
-    plot2D: Plot2D
+    plot2D: Plot2D | PlotUncertain2D
     result: int
 
     @classmethod

--- a/ptychodus/controller/reconstructor.py
+++ b/ptychodus/controller/reconstructor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 import logging
+import itertools
 
 from PyQt5.QtCore import Qt, QStringListModel
 from PyQt5.QtGui import QPixmap
@@ -208,14 +209,14 @@ class ReconstructorParametersController(Observer):
         ax.set_ylabel(axisY.label)
         ax.grid(True)
 
-        if len(axisX.series) == len(axisY.series):
-            for sx, sy in zip(axisX.series, axisY.series):
+        if (
+            (len(axisX.series) == len(axisY.series)) or
+            (len(axisX.series) == 1 and len(axisY.series) >= 1)
+        ):
+            for sx, sy in zip(itertools.cycle(axisX.series), axisY.series):
                 ax.plot(sx.values, sy.values, '.-', label=sy.label, linewidth=1.5)
-        elif len(axisX.series) == 1:
-            sx = axisX.series[0]
-
-            for sy in axisY.series:
-                ax.plot(sx.values, sy.values, '.-', label=sy.label, linewidth=1.5)
+                if hasattr(sy, 'hi') and hasattr(sy, 'lo'):
+                    ax.fill_between(sx.values, sy.lo, sy.hi, alpha=0.2)
         else:
             logger.error('Failed to broadcast plot series!')
 

--- a/ptychodus/model/reconstructor/core.py
+++ b/ptychodus/model/reconstructor/core.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import logging
 
 from ...api.observer import Observable, Observer
-from ...api.plot import Plot2D, PlotAxis, PlotSeries
+from ...api.plot import Plot2D, PlotAxis, PlotSeries, PlotUncertain2D
 from ...api.reconstructor import ReconstructorLibrary
 from ...api.settings import SettingsRegistry
 from ..data import ActiveDiffractionDataset
@@ -66,7 +66,7 @@ class ReconstructorPresenter(Observable, Observer):
         )
         self.notifyObservers()
 
-    def getPlot(self) -> Plot2D:
+    def getPlot(self) -> Plot2D | PlotUncertain2D:
         return self._plot2D
 
     @property

--- a/ptychodus/model/tike/reconstructor.py
+++ b/ptychodus/model/tike/reconstructor.py
@@ -11,7 +11,7 @@ import tike.ptycho
 
 from ...api.object import ObjectArrayType
 from ...api.object import ObjectPoint
-from ...api.plot import Plot2D, PlotAxis, PlotSeries
+from ...api.plot import PlotUncertain2D, PlotUncertainAxis, PlotUncertainSeries, PlotAxis, PlotSeries
 from ...api.probe import ProbeArrayType
 from ...api.reconstructor import Reconstructor, ReconstructInput, ReconstructOutput
 from ...api.scan import Scan, ScanPoint, TabularScan
@@ -107,8 +107,8 @@ class TikeReconstructor:
 
         return 1
 
-    def _plotCosts(self, costs: Sequence[Sequence[float]]) -> Plot2D:
-        plot = Plot2D.createNull()
+    def _plotCosts(self, costs: Sequence[Sequence[float]]) -> PlotUncertain2D:
+        plot = PlotUncertain2D.createNull()
         numIterations = len(costs)
 
         if numIterations > 0:
@@ -117,7 +117,7 @@ class TikeReconstructor:
             midCost: list[float] = list()
             maxCost: list[float] = list()
 
-            seriesYList: list[PlotSeries] = list()
+            seriesYList: list[PlotUncertainSeries] = list()
 
             for values in costs:
                 minCost.append(min(values))
@@ -125,14 +125,17 @@ class TikeReconstructor:
                 maxCost.append(max(values))
 
             seriesYList = [
-                PlotSeries(label='Minimum', values=minCost),
-                PlotSeries(label='Median', values=midCost),
-                PlotSeries(label='Maximum', values=maxCost),
+                PlotUncertainSeries(
+                    label='Median',
+                    lo=minCost,
+                    values=midCost,
+                    hi=maxCost,
+                ),
             ]
 
-            plot = Plot2D(
+            plot = PlotUncertain2D(
                 axisX=PlotAxis(label='Iteration', series=[seriesX]),
-                axisY=PlotAxis(label='Cost', series=seriesYList),
+                axisY=PlotUncertainAxis(label='Cost', series=seriesYList),
             )
 
         return plot


### PR DESCRIPTION
A new dataclass family is created based on Plot2D. PlotUncertain2D is a 2D line plot, but the lines can now include lo,hi series to express uncertainty ranges.

The TikeReconstructor now returns a PlotUncertain2D of one line (median) instead of a Plot2D with three lines (min, median, max) representing the objective function.

The changes are backwards compatible, so they do not affect other methods which use Plot2D.

Closes #69 

![uncertain](https://github.com/AdvancedPhotonSource/ptychodus/assets/9604511/6ae70007-d823-4417-8ecf-621db8a47f8f)
