### PR TITLE
BUG: Use average (measured) scan positions in Orchestra dataloader

### DIFF
--- a/ptychodus/plugins/lynxOrchestraScanFile.py
+++ b/ptychodus/plugins/lynxOrchestraScanFile.py
@@ -14,8 +14,8 @@ class LYNXOrchestraScanFileReader(ScanFileReader):
     SIMPLE_NAME: Final[str] = 'LYNXOrchestra'
     MICRONS_TO_METERS: Final[float] = 1.e-6
     DATA_POINT_COLUMN: Final[int] = 0
-    X_COLUMN: Final[int] = 2
-    Y_COLUMN: Final[int] = 5
+    X_COLUMN: Final[int] = 3
+    Y_COLUMN: Final[int] = 6
 
     EXPECTED_HEADER: Final[list[str]] = [
         'DataPoint',


### PR DESCRIPTION
Columns 2,5 load the Target_x and Target_y coordinates instead of the (interferometer?) measured coordinates (columns 3,6) from the LYNX Orchestrea scan position files.