### PR TITLE
API: Invert each scan axes for LYNX dataloaders

### DIFF
--- a/ptychodus/plugins/lynxOrchestraScanFile.py
+++ b/ptychodus/plugins/lynxOrchestraScanFile.py
@@ -72,8 +72,8 @@ class LYNXOrchestraScanFileReader(ScanFileReader):
 
                 data_point = int(row[self.DATA_POINT_COLUMN])
                 point = ScanPoint(
-                    x=float(row[self.X_COLUMN]) * self.MICRONS_TO_METERS,
-                    y=float(row[self.Y_COLUMN]) * self.MICRONS_TO_METERS,
+                    x=-float(row[self.X_COLUMN]) * self.MICRONS_TO_METERS,
+                    y=-float(row[self.Y_COLUMN]) * self.MICRONS_TO_METERS,
                 )
                 pointSeqMap[data_point].append(point)
 

--- a/ptychodus/plugins/lynxSoftGlueZynqScanFile.py
+++ b/ptychodus/plugins/lynxSoftGlueZynqScanFile.py
@@ -69,8 +69,8 @@ class LYNXSoftGlueZynqScanFileReader(ScanFileReader):
 
                 detector_count = int(row[DETECTOR_COUNT])
                 point = ScanPoint(
-                    x=float(row[X]) * LYNXSoftGlueZynqScanFileReader.MICRONS_TO_METERS,
-                    y=float(row[Y]) * LYNXSoftGlueZynqScanFileReader.MICRONS_TO_METERS,
+                    x=-float(row[X]) * LYNXSoftGlueZynqScanFileReader.MICRONS_TO_METERS,
+                    y=-float(row[Y]) * LYNXSoftGlueZynqScanFileReader.MICRONS_TO_METERS,
                 )
                 pointSeqMap[detector_count].append(point)
 


### PR DESCRIPTION
Inverting the axes (multiply the scan positions by -1) matches the existing reconstruction conventions/exceptions for foldslice. Generally, inverting the axes should cause a rotation of the diffraction pattern by 180, so I'm not sure why this hasn't been an obvious bug.

I have tested some datasets, and it appears that inverting the axes (what this patch does) makes a smoother convergence. Using many probe modes hides the issue which is why it may have not been caught before.

Reconstructions with a single probe mode and all the same reconstruction parameters except for scan axes orientation.

### Before (Orchestra and SoftGlueZynq)
![Screenshot from 2024-02-20 11-31-24](https://github.com/AdvancedPhotonSource/ptychodus/assets/9604511/47abf8b0-4d89-4a94-9a8f-29c362d49925)
![Screenshot from 2024-02-20 13-54-12](https://github.com/AdvancedPhotonSource/ptychodus/assets/9604511/1a8e3ce4-e897-4588-9940-38644595b123)

### This PR
![Screenshot from 2024-02-20 11-31-08](https://github.com/AdvancedPhotonSource/ptychodus/assets/9604511/7f9c35b0-366b-4af0-80fd-3994dc48dd12)

![Screenshot from 2024-02-20 13-54-02](https://github.com/AdvancedPhotonSource/ptychodus/assets/9604511/27564490-b632-40b3-8ba6-2bc9555a3e98)

