### PR TITLE
NEW: Add update magnitude limit parameter to Position Options

### DIFF
--- a/ptychodus/controller/tike/positionCorrection.py
+++ b/ptychodus/controller/tike/positionCorrection.py
@@ -27,6 +27,7 @@ class TikePositionCorrectionController(Observer):
 
         view.positionRegularizationCheckBox.toggled.connect(
             presenter.setPositionRegularizationEnabled)
+        view.updateMagnitudeLimitLineEdit.valueChanged.connect(presenter.setUpdateMagnitudeLimit)
 
         controller._syncModelToView()
 
@@ -37,6 +38,7 @@ class TikePositionCorrectionController(Observer):
 
         self._view.positionRegularizationCheckBox.setChecked(
             self._presenter.isPositionRegularizationEnabled())
+        self._view.updateMagnitudeLimitLineEdit.setValue(self._presenter.getUpdateMagnitudeLimit())
 
     def update(self, observable: Observable) -> None:
         if observable is self._presenter:

--- a/ptychodus/model/tike/positionCorrection.py
+++ b/ptychodus/model/tike/positionCorrection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from decimal import Decimal
 
 from ...api.settings import SettingsGroup, SettingsRegistry
 from .adaptiveMoment import TikeAdaptiveMomentPresenter, TikeAdaptiveMomentSettings
@@ -12,6 +13,7 @@ class TikePositionCorrectionSettings(TikeAdaptiveMomentSettings):
             'UsePositionCorrection', False)
         self.usePositionRegularization = settingsGroup.createBooleanEntry(
             'UsePositionRegularization', False)
+        self.updateMagnitudeLimit = settingsGroup.createRealEntry('Update Magnitude Limit', '0.0')
         # TODO transform: Global transform of positions.
         # TODO origin: The rotation center of the transformation.
 
@@ -42,3 +44,9 @@ class TikePositionCorrectionPresenter(TikeAdaptiveMomentPresenter[TikePositionCo
 
     def setPositionRegularizationEnabled(self, enabled: bool) -> None:
         self._settings.usePositionRegularization.value = enabled
+
+    def getUpdateMagnitudeLimit(self) -> Decimal:
+        return self._settings.updateMagnitudeLimit.value
+
+    def setUpdateMagnitudeLimit(self, value: Decimal) -> None:
+        self._settings.updateMagnitudeLimit.value = value

--- a/ptychodus/model/tike/reconstructor.py
+++ b/ptychodus/model/tike/reconstructor.py
@@ -67,6 +67,7 @@ class TikeReconstructor:
                 vdecay=float(settings.vdecay.value),
                 mdecay=float(settings.mdecay.value),
                 use_position_regularization=settings.usePositionRegularization.value,
+                update_magnitude_limit=float(settings.updateMagnitudeLimit.value),
             )
 
         return options

--- a/ptychodus/view/tike.py
+++ b/ptychodus/view/tike.py
@@ -115,6 +115,7 @@ class TikePositionCorrectionView(QGroupBox):
         super().__init__('Position Correction', parent)
         self.positionRegularizationCheckBox = QCheckBox('Use Regularization')
         self.adaptiveMomentView = TikeAdaptiveMomentView.createInstance()
+        self.updateMagnitudeLimitLineEdit = DecimalLineEdit.createInstance()
 
     @classmethod
     def createInstance(cls, parent: Optional[QWidget] = None) -> TikePositionCorrectionView:
@@ -122,10 +123,14 @@ class TikePositionCorrectionView(QGroupBox):
 
         view.positionRegularizationCheckBox.setToolTip(
             'Whether the positions are constrained to fit a random error plus affine error model.')
+        view.updateMagnitudeLimitLineEdit.setToolTip(
+            'When set to a positive number, x and y update magnitudes are clipped (limited) '
+            'to this value.')
 
         layout = QFormLayout()
         layout.addRow(view.positionRegularizationCheckBox)
         layout.addRow(view.adaptiveMomentView)
+        layout.addRow('Update Magnitude Limit:', view.updateMagnitudeLimitLineEdit)
         view.setLayout(layout)
 
         return view

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
 
 [options.extras_require]
 ptychonn = ptychonn ==0.2.*
-tike = tike ==0.25.*
+tike = tike ==0.25.*,>=0.25.3
 gui = pyqt5 ==5.*
 globus =
     gladier >=0.9


### PR DESCRIPTION
Enable the end user to set the update_magnitude_limit parameter from the GUI. This parameter was added in [v0.25.3](https://github.com/AdvancedPhotonSource/tike/releases/tag/v0.25.3).