### PR TITLE
CI: Publish apptainers with ptychodus installed

### DIFF
--- a/.github/workflows/apptainer.yml
+++ b/.github/workflows/apptainer.yml
@@ -1,0 +1,47 @@
+# This workflow builds an apptainer with tike installed
+
+name: Publish Apptainer
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  publish-apptainer-to-ghcr:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          cuda-version:
+            - "11.8"
+            - "12.0"
+          target-arch:
+            - "x86_64"
+            - "aarch64"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - uses: eWaterCycle/setup-apptainer@v2
+      with:
+        apptainer-version: 1.3.0
+    - name: Build container from definition
+      run: >
+        apptainer build
+        --build-arg cuda_version=${{ matrix.cuda-version }}
+        --build-arg target_arch=${{ matrix.target-arch }}
+        apptainer.sif
+        apptainer/${{ github.event.repository.name }}.def
+    - name: Upload to container registry
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | apptainer registry login -u ${{ github.actor }} --password-stdin oras://ghcr.io
+        apptainer push apptainer.sif oras://ghcr.io/${GITHUB_REPOSITORY,,}:${{ github.ref_name }}-${{ matrix.target-arch }}-cuda${{ matrix.cuda-version }}

--- a/.github/workflows/apptainer.yml
+++ b/.github/workflows/apptainer.yml
@@ -1,4 +1,4 @@
-# This workflow builds an apptainer with tike installed
+# This workflow builds an apptainer with ptychodus installed
 
 name: Publish Apptainer
 

--- a/apptainer/ptychodus.def
+++ b/apptainer/ptychodus.def
@@ -1,9 +1,9 @@
 Bootstrap: docker
-From: registry.fedoraproject.org/fedora-minimal:40
+From: registry.fedoraproject.org/fedora-minimal:40-{{ target_arch }}
 
 %arguments
 target_arch="x86_64"
-cuda_version="12.2"
+cuda_version="12.0"
 
 %post
 curl -L -o conda-installer.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-{{ target_arch }}.sh

--- a/apptainer/ptychodus.def
+++ b/apptainer/ptychodus.def
@@ -1,0 +1,16 @@
+Bootstrap: docker
+From: registry.fedoraproject.org/fedora-minimal:40
+
+%arguments
+target_arch="x86_64"
+cuda_version="12.2"
+
+%post
+curl -L -o conda-installer.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-{{ target_arch }}.sh
+bash conda-installer.sh -b -p "/opt/miniconda"
+rm conda-installer.sh
+CONDA_OVERRIDE_CUDA={{ cuda_version }} /opt/miniconda/bin/conda install ptychodus-all cuda-version={{ cuda_version }} -c conda-forge --yes
+/opt/miniconda/bin/conda clean --all --yes
+
+%runscript
+/opt/miniconda/bin/python -m ptychodus "$@"


### PR DESCRIPTION
This GitHub Actions workflow and def file build an apptainer (singularity container) on github actions and publishes it to the Github Package repository whenever there is addition to the main branch or a release. The containers are built for multiple CUDA versions and also both x86 and ARM so that ptychodus can be run on grace hopper? (actually I don't know if it will run on grace hopper, but I need the container before I can test it out).