### PR TITLE
CI: Build containers from source instead of from conda package

### DIFF
--- a/.github/workflows/apptainer.yml
+++ b/.github/workflows/apptainer.yml
@@ -39,6 +39,7 @@ jobs:
         apptainer build
         --build-arg cuda_version=${{ matrix.cuda-version }}
         --build-arg target_arch=${{ matrix.target-arch }}
+        --build-arg pkg_version=${{ github.ref_name }}
         apptainer.sif
         apptainer/${{ github.event.repository.name }}.def
     - name: Upload to container registry

--- a/apptainer/ptychodus.def
+++ b/apptainer/ptychodus.def
@@ -2,14 +2,24 @@ Bootstrap: docker
 From: registry.fedoraproject.org/fedora-minimal:40-{{ target_arch }}
 
 %arguments
-target_arch="x86_64"
-cuda_version="12.0"
+target_arch=x86_64
+cuda_version=12.0
+pkg_version=master
 
 %post
 curl -L -o conda-installer.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-{{ target_arch }}.sh
 bash conda-installer.sh -b -p "/opt/miniconda"
 rm conda-installer.sh
-CONDA_OVERRIDE_CUDA={{ cuda_version }} /opt/miniconda/bin/conda install ptychodus-all cuda-version={{ cuda_version }} -c conda-forge --yes
+/opt/miniconda/bin/conda install unzip --yes
+curl -L -o source.zip https://github.com/AdvancedPhotonSource/ptychodus/archive/{{ pkg_version }}.zip
+/opt/miniconda/bin/unzip source.zip
+rm source.zip
+cd ptychodus*
+CONDA_OVERRIDE_CUDA={{ cuda_version }} /opt/miniconda/bin/conda install cuda-version={{ cuda_version }} --file requirements.txt -c conda-forge --yes
+/opt/miniconda/bin/pip install . --no-deps --no-build-isolation
+/opt/miniconda/bin/pip check
+cd ..
+rm ptychodus* -rf
 /opt/miniconda/bin/conda clean --all --yes
 
 %runscript

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+gladier >=0.9
+gladier-tools >=0.5
+h5py =3.*
+hdf5plugin
+matplotlib-base =3.*
+numpy =1.*
+pip
+psutil =5.*
+ptychonn =0.2.*
+pyqt =5.*
+python >=3.10
+pytorch=*=cuda*
+scikit-image =0.*
+scipy >=1.6,<2.0
+setuptools >=46.4.0
+setuptools_scm >=7
+setuptools_scm_git_archive
+tifffile =2023.*
+tike >=0.25.3,<0.26
+watchdog =3.*
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ gladier-tools >=0.5
 h5py =3.*
 hdf5plugin
 matplotlib-base =3.*
-mpi =*=openmpi*
 numpy =1.*
+nompi
 pip
 psutil =5.*
 ptychonn =0.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ gladier-tools >=0.5
 h5py =3.*
 hdf5plugin
 matplotlib-base =3.*
+mpi =*=nompi*
 numpy =1.*
-nompi
 pip
 psutil =5.*
 ptychonn =0.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ gladier-tools >=0.5
 h5py =3.*
 hdf5plugin
 matplotlib-base =3.*
-mpi =*=nompi*
 numpy =1.*
 pip
 psutil =5.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ h5py =3.*
 hdf5plugin
 matplotlib-base =3.*
 numpy =1.*
+mpi =*=openmpi*
 pip
 psutil =5.*
 ptychonn =0.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ gladier-tools >=0.5
 h5py =3.*
 hdf5plugin
 matplotlib-base =3.*
-numpy =1.*
 mpi =*=openmpi*
+numpy =1.*
 pip
 psutil =5.*
 ptychonn =0.2.*


### PR DESCRIPTION
In order to release containers and conda packages from the same release simultaneously, the contains must be build separately from source. This PR does that. The downside is that an additional requirements file must be maintained because the container requires a non "impli" version of mpi and I couldn't figure out a way to quickly convert the setup.cfg file to plain text.