### PR TITLE
DOC: Set default logging level to INFO

### DIFF
--- a/ptychodus/model/core.py
+++ b/ptychodus/model/core.py
@@ -40,11 +40,13 @@ from .workflow import (WorkflowAuthorizationPresenter, WorkflowCore, WorkflowExe
 logger = logging.getLogger(__name__)
 
 
-def configureLogger() -> None:
-    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
-                        stream=sys.stdout,
-                        encoding='utf-8',
-                        level=logging.DEBUG)
+def configureLogger(isDeveloperModeEnabled: bool) -> None:
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stdout,
+        encoding="utf-8",
+        level=logging.DEBUG if isDeveloperModeEnabled else logging.INFO,
+    )
     logging.getLogger('matplotlib').setLevel(logging.WARNING)
     logging.getLogger('tike').setLevel(logging.WARNING)
 
@@ -62,7 +64,7 @@ class ModelCore:
                  settingsFile: Path | None = None,
                  *,
                  isDeveloperModeEnabled: bool = False) -> None:
-        configureLogger()
+        configureLogger(isDeveloperModeEnabled)
         self.rng = numpy.random.default_rng()
         self._pluginRegistry = PluginRegistry.loadPlugins()
 


### PR DESCRIPTION
Only use the DEBUG logging level if developer mode is enabled. Jeff noted that the Ptychodus logs are too verbose to be useful. Looking at the logs it seems that the default level is DEBUG, but it should be INFO for general users.