### PR TITLE
Phase unwrapping fixes

### DIFF
--- a/src/ptychodus/model/analysis/phaseUnwrapper.py
+++ b/src/ptychodus/model/analysis/phaseUnwrapper.py
@@ -334,7 +334,7 @@ def integrate_image_2d_fourier(grad_y: NDArray, grad_x: NDArray) -> NDArray:
     f = numpy.fft.fft2(grad_x + 1j * grad_y)
     y, x = numpy.fft.fftfreq(shape[0]), numpy.fft.fftfreq(shape[1])
 
-    r = numpy.exp(2j * numpy.pi * (x + y[:, None]))
+    r = 1.0
     r = r / (2j * numpy.pi * (x + 1j * y[:, None]))
     r[0, 0] = 0
     integrated_image = f * r

--- a/src/ptychodus/model/analysis/phaseUnwrapper.py
+++ b/src/ptychodus/model/analysis/phaseUnwrapper.py
@@ -137,8 +137,7 @@ def vignett(img: NDArray, margin: int = 20, sigma: float = 1.0) -> NDArray:
         mask = ndimage.convolve1d(mask, gauss_win, axis=i_dim, mode='constant')
         mask_final_slicer = [slice(None)] * i_dim + [slice(len(gauss_win), len(gauss_win) + margin)]
 
-        for slicer in mask_final_slicer:
-            mask = mask[slicer]
+        mask = mask[tuple(mask_final_slicer)]
 
         mask = numpy.where(mask < 1e-3, 0, mask)
 
@@ -335,7 +334,7 @@ def integrate_image_2d_fourier(grad_y: NDArray, grad_x: NDArray) -> NDArray:
     y, x = numpy.fft.fftfreq(shape[0]), numpy.fft.fftfreq(shape[1])
 
     r = 1.0
-    r = r / (2j * numpy.pi * (x + 1j * y[:, None]))
+    r = r / (2j * numpy.pi * (x + 1j * y[:, None]) + 1e-15)
     r[0, 0] = 0
     integrated_image = f * r
     integrated_image = numpy.fft.ifft2(integrated_image)


### PR DESCRIPTION
# Fixes

## One-pixel shift in Fourier image integration

The phase unwrapping function was originally adapted from PtychoShelves. In the image integration routine (`get_img_int_2D.m`), they apply a phase ramp to the transfer function's numerator which effectively conducts a 1-pixel shift. As they commented in their Matlab code, this is necessary to make the unwrapped phase aligned with the input, but they are unsure why this is needed:
```
    % not sure why, but it seems to need also shift by 1 pixels to make it
    % consistent with gradient 
    X = exp((2i*pi)*(xgrid+ygrid'));
```
However, in Python (with either PyTorch or NumPy), we found the unwrapped phase would have a 1-pixel offset compared to the input **with** this phase ramp, so we shouldn't do it here. The numerator of the transfer function is set to 1 instead. 

## Tensor slicing

- Corrected the way of slicing a buffer with a list of slice object without unpacking. 
- Prevented division by zero in the vignette function. 